### PR TITLE
Bug fixes & minor code cleanup

### DIFF
--- a/postinit/prefabs/mushroom_hats.lua
+++ b/postinit/prefabs/mushroom_hats.lua
@@ -279,7 +279,7 @@ end
 
 local function TryKillHost(inst,owner)
 	-- Death is the only way out.
-	owner.components.combat:GetAttacked(-20,inst)
+	owner.components.combat:GetAttacked(inst, 20)
 	inst:DoTaskInTime(0,function(inst) 
 		if inst.owner and inst.owner.components.health and not inst.owner.components.health:IsDead() then
 			local owner = inst.owner

--- a/postinit/stategraphs/SGkoalefant.lua
+++ b/postinit/stategraphs/SGkoalefant.lua
@@ -10,7 +10,10 @@ env.AddStategraphPostInit("koalefant", function(inst)
     if doattackeventhandler then
         local doattackeventhandler_fn = doattackeventhandler.fn
         doattackeventhandler.fn = function(inst, data, ...)
-            if not (inst.components.health and inst.components.health:IsDead() or inst.sg:HasStateTag("electrocute")) and (inst.sg:HasStateTag("charging") or inst:HasTag("chargespeed")) then
+            if inst.sg.mem.wantstostomp then
+                inst.sg.mem.wantstostomp = nil
+                inst.sg:GoToState("stomp")
+            elseif not (inst.components.health and inst.components.health:IsDead() or inst.sg:HasStateTag("electrocute")) and (inst.sg:HasStateTag("charging") or inst:HasTag("chargespeed")) then
                 inst.sg:GoToState("chargeattack", data.target)
             else
                 doattackeventhandler_fn(inst, data, ...)
@@ -65,7 +68,8 @@ env.AddStategraphPostInit("koalefant", function(inst)
                     return
                 elseif not inst.sg:HasAnyStateTag("attack", "busy", "electrocute", "charging") and math.random() > .66
                     and inst.components.combat.target and 4 > inst:GetDistanceSqToInst(inst.components.combat.target) and inst.counterattack then
-                    inst.sg:GoToState("stomp") 
+                    inst.sg.mem.wantstostomp = true
+                    inst.components.combat:ResetCooldown()
                     return
                 end
             end

--- a/postinit/stategraphs/SGpigbunny.lua
+++ b/postinit/stategraphs/SGpigbunny.lua
@@ -12,6 +12,9 @@ env.AddStategraphPostInit("pig", function(inst)
                 local nstate = "attack"
                 if inst.sg:HasStateTag("charging") then
                     nstate = "charge_attack"
+                elseif inst.sg.mem.wantstocounter then
+                    inst.sg.mem.wantstocounter = nil
+                    nstate = "counterattack_pre"
                 end
                 if not (inst.components.health and inst.components.health:IsDead())
                     and not inst.sg:HasStateTag("busy") then
@@ -28,6 +31,10 @@ env.AddStategraphPostInit("pig", function(inst)
             if CommonHandlers.TryElectrocuteOnAttacked(inst, data) then
                 return
             elseif inst:HasTag("pigattacker") and not inst:HasTag("werepig") and not inst.sg:HasAnyStateTag("counter", "caninterrupt", "electrocute") then
+                if inst.sg.mem.wantstocounter then
+                    inst.components.combat:ResetCooldown()
+                    return
+                end
                 if inst.counter then
                     inst.counter = inst.counter + 1
                     if inst.countertask then
@@ -46,7 +53,8 @@ env.AddStategraphPostInit("pig", function(inst)
                         inst.countertask = nil
                     end
                     inst.counter = 0
-                    inst.sg:GoToState("counterattack_pre")
+                    inst.sg.mem.wantstocounter = true
+                    inst.components.combat:ResetCooldown()
                     return
                 end
             end

--- a/postinit/stategraphs/SGspider.lua
+++ b/postinit/stategraphs/SGspider.lua
@@ -58,7 +58,12 @@ env.AddStategraphPostInit("spider", function(inst)
     local _OldAttackEvent = inst.events["doattack"] and inst.events["doattack"].fn
     if _OldAttackEvent then
         inst.events["doattack"].fn = function(inst, data, ...)
-            if not (inst.sg:HasStateTag("busy") or inst.components.health:IsDead()) then
+            if (not (inst.sg:HasStateTag("busy") or inst.components.health:IsDead())) and data.target and data.target:IsValid() then
+                if inst.sg.mem.wantstoevade then
+                    inst.sg.mem.wantstoevade = nil
+                    inst.sg:GoToState("evade_loop")
+                    return
+                end
                 if inst:HasTag("spider_regular") then
                     inst.sg:GoToState(data.target:IsValid() and not (inst:IsNear(data.target, TUNING.SPIDER_WARRIOR_MELEE_RANGE)
                         or (TUNING.DSTU.REGSPIDERJUMP == false and inst:HasTag("spider_regular"))) and "warrior_attack" or "attack", data.target) -- Do leap attack
@@ -83,7 +88,9 @@ env.AddStategraphPostInit("spider", function(inst)
                 elseif TUNING.DSTU.SPIDERWARRIORCOUNTER and inst:HasTag("spider_warrior") and not inst:HasTag("trapdoorspider")
                     and not (inst.sg:HasAnyStateTag("caninterrupt", "electrocute") or inst:HasTag("forcestunned")) then
                     if not inst.sg:HasAnyStateTag("attack", "evade") and inst.components.combat.target then -- don't interrupt attack or exit shield
-                        inst.sg:GoToState("evade_loop")
+                        inst.sg.mem.wantstoevade = true
+                        inst.components.combat:ResetCooldown()
+                        inst.sg:GoToState("idle")
                     end
                     return
                 end
@@ -266,12 +273,7 @@ env.AddStategraphPostInit("spider", function(inst)
                     inst.components.locomotor:EnableGroundSpeedMultiplier(false)
                 end
             end,
-            --[[events =
-            {
-                EventHandler("animover", function(inst) 
-                    inst.sg:GoToState("evade_pst") 
-                end ),
-            },]]
+
             timeline =
             {
                 TimeEvent(3 * FRAMES, function(inst) inst.Physics:SetMotorVel(-20, 0, 0) end),
@@ -279,44 +281,11 @@ env.AddStategraphPostInit("spider", function(inst)
             },
 
             ontimeout = function(inst)
-                inst.sg:GoToState("evade_pst")
-            end,
-
-            onexit = function(inst)
-                inst.components.locomotor:EnableGroundSpeedMultiplier(true)
-                inst.Physics:ClearMotorVelOverride()
-                inst.components.locomotor:Stop()
-            end,
-        },
-        State{
-            name = "evade_pst",
-            tags = {"busy", "evade", "no_stun"},
-
-            onenter = function(inst)
                 if inst.components.combat.target and inst.components.combat.target:IsValid() then
-                    inst:ForceFacePoint(inst.components.combat.target:GetPosition())
+                    inst.components.combat:ResetCooldown()
                 end
-                inst.components.locomotor:Stop()
-                --inst.AnimState:PlayAnimation("evade_pst")
+                inst.sg:GoToState("idle")
             end,
-
-            events =
-            {
-                EventHandler("animover", function(inst)
-                    if inst.components.combat.target and inst.components.combat.target:IsValid() then
-                        local JUMP_DISTANCE = 3
-                        local distance = inst:GetDistanceSqToInst(inst.components.combat.target)
-
-                        if distance > JUMP_DISTANCE * JUMP_DISTANCE then
-                            inst.sg:GoToState("warrior_attack", inst.components.combat.target)
-                        else
-                            inst.sg:GoToState("attack", inst.components.combat.target)
-                        end
-                    else
-                        inst.sg:GoToState("idle")
-                    end
-                end),
-            },
 
             onexit = function(inst)
                 inst.components.locomotor:EnableGroundSpeedMultiplier(true)

--- a/scripts/prefabs/iceshield.lua
+++ b/scripts/prefabs/iceshield.lua
@@ -1,5 +1,6 @@
-local function OnHealthDelta(inst, oldpercent, newpercent)
-    if oldpercent > newpercent then
+local function OnHealthDelta(inst, oldpercent, newpercent, overtime, cause, afflicter, amount)
+    if amount < 0 and ((not overtime) or (cause == "fire")) and (GetTime() - inst.lasthitfxtime) > 0.1 then
+        inst.lasthitfxtime = GetTime()
         inst._parent.SoundEmitter:PlaySound("meta4/mortars/cannonball_hit_ice")
         SpawnPrefab("mining_ice_fx").Transform:SetPosition(inst._parent.Transform:GetWorldPosition())
     end
@@ -56,14 +57,22 @@ local function Init(inst, parent, fx_symbol, tier)
     inst.Transform:SetPosition(parent.Transform:GetWorldPosition())
 
     if parent.components.health ~= nil then
-        parent.components.health.redirect = function(target, amount, overtime, cause, ignore_invincible, afflicter, ignore_absorb, ...)
+        if parent.components.health.redirect then
+            inst.redirect_old = parent.components.health.redirect
+        end
+        parent.components.health.redirect = function(self, amount, overtime, cause, ...)
+            if amount >= 0 then
+                return inst.redirect_old and inst.redirect_old(self, amount, overtime, cause, ...) or false
+            end
             if inst.components.health ~= nil and inst:IsValid() then
                 if cause == "fire" then
                     amount = amount * 10
                     SpawnPrefab("washashore_puddle_fx").Transform:SetPosition(parent.Transform:GetWorldPosition())
                 end
 
-                return inst.components.health:DoDelta(amount, overtime, cause, ignore_invincible, afflicter, ignore_absorb, ...)
+                inst.components.health:DoDelta(amount, overtime, cause, ...)
+
+                return true
             end
         end
     end
@@ -132,10 +141,10 @@ local function fn()
         inst:Remove()
     end)
 
-    inst:ListenForEvent("removed", function(inst)
+    inst:ListenForEvent("onremove", function(inst)
         if inst._parent ~= nil then
             inst._parent:RemoveTag("ice_shielded")
-            inst._parent.components.health.redirect = nil
+            inst._parent.components.health.redirect = inst.redirect_old and inst.redirect_old or nil
         end
     end)
 

--- a/scripts/stategraphs/SGum_pepperdragon.lua
+++ b/scripts/stategraphs/SGum_pepperdragon.lua
@@ -106,28 +106,6 @@ local function ShootFire(inst,total_flame)
 	end
 end
 
-local function GetPissy(inst)
-	if not inst.components.timer:TimerExists("pissedoff") then
-		inst.components.timer:StopTimer("pissedoff")
-	end
-	inst.components.timer:StartTimer("pissedoff",60) -- 1 minute of piss off time.
-	inst.check_ready_flame = inst:DoPeriodicTask(5,function(inst) -- see if we happen to be in a good position for lots of fire.
-		if not inst.components.timer:TimerExists("pissedoff") then
-			if inst.check_ready_flame then
-				inst.check_ready_flame:Cancel()
-				inst.check_ready_flame = nil
-			end
-		else
-			if not inst.components.timer:TimerExists("flame_cd") then
-				local target = inst.components.combat and inst.components.combat.target or nil
-				if not inst.sg:HasStateTag("busy") and (target and inst:GetDistanceSqToInst(target) < 30) then
-					inst.sg:GoToState("flame_pre")
-				end
-			end
-		end
-	end)
-end
-
 local actionhandlers =
 {
     ActionHandler(ACTIONS.GOHOME, "gohome"),
@@ -360,7 +338,10 @@ local states=
             inst.AnimState:PlayAnimation("hit")
             inst.Physics:Stop()
 			CommonHandlers.UpdateHitRecoveryDelay(inst)
-			GetPissy(inst)
+            if not inst.components.timer:TimerExists("pissedoff") then
+                inst.components.timer:StopTimer("pissedoff")
+            end
+            inst.components.timer:StartTimer("pissedoff",60) -- 1 minute of piss off time.
         end,
 
         events=

--- a/scripts/stategraphs/SGum_pepperdragon.lua
+++ b/scripts/stategraphs/SGum_pepperdragon.lua
@@ -140,7 +140,10 @@ local events=
     CommonHandlers.OnAttacked(),
     EventHandler("doattack", function(inst)
 		if not (inst.components.health:IsDead() or inst.sg:HasStateTag("electrocute") or inst.sg:HasStateTag("busy")) then
-			if (inst.components.timer:TimerExists("pissedoff") and not inst.components.timer:TimerExists("flame_cd")) or inst.flamecount > 0 then
+            if inst.sg.mem.wantstostomp then
+                inst.sg.mem.wantstostomp = nil
+                inst.sg:GoToState("stomp")
+			elseif (inst.components.timer:TimerExists("pissedoff") and not inst.components.timer:TimerExists("flame_cd")) or inst.flamecount > 0 then
 				inst.sg:GoToState("flame_pre")
 			else
 				inst.sg:GoToState("attack")
@@ -193,10 +196,6 @@ local states=
                 inst.AnimState:PushAnimation("idle1", true)
             else
                 inst.AnimState:PlayAnimation("idle1", true)
-            end
-
-            if inst:HasTag("teenbird") then
-                inst.sg:SetTimeout(4 + 4*math.random())
             end
         end,
 
@@ -354,7 +353,9 @@ local states=
         tags = {"hit"},
 
         onenter = function(inst)
-			inst.tolerance = inst.tolerance + 0.1+math.random(1,20)*0.1
+            if not inst.sg.mem.wantstostomp then
+			    inst.tolerance = inst.tolerance + 0.1 + (math.random() * 0.2)
+            end
             inst.SoundEmitter:PlaySound("dontstarve/creatures/together/toad_stool/hit")
             inst.AnimState:PlayAnimation("hit")
             inst.Physics:Stop()
@@ -364,13 +365,13 @@ local states=
 
         events=
         {
-            EventHandler("animover", function(inst) 
-				if inst.tolerance > 1 then
-					inst.tolerance = 0
-					inst.sg:GoToState("stomp")				
-				else
-					inst.sg:GoToState("idle") 
-				end 
+            EventHandler("animover", function(inst)
+                if inst.tolerance > 1 then
+                    inst.tolerance = 0
+                    inst.sg.mem.wantstostomp = true
+                    inst.components.combat:ResetCooldown()
+                end
+				inst.sg:GoToState("idle")
 			end),
         },
     },


### PR DESCRIPTION
Fixed:
- Funcaps crashing when trying to take them off
- Icy Barrier from Spaghetti Cryonara:
    - Absorbing the player's healing
    - Making Wanda receive healing and damage instantly instead of over time
- Counter attacks happening while a creature is panicking. This affects:
    - Capsidragon's Stomp
    - Koalefant's Stomp
    - Pigman's Charge
    - Spider Warrior's Backstep