### PR TITLE
```

### DIFF
--- a/init/init_tuning.lua
+++ b/init/init_tuning.lua
@@ -250,6 +250,7 @@ TUNING.DSTU = {
     WORMWOOD_CONFIG_FIRE = GetModConfigData("wormwood_fire"),
     WORMWOOD_CONFIG_PLANTS = GetModConfigData("wormwood_plants"),
     WORMWOOD_CONFIG_TRAPS = GetModConfigData("wormwood_trapbuffs"),
+    WORMWOOD_PHOTOSYNTHESIS = GetModConfigData("wormwood_photosynthesis"),
     -- Warly
     WARLY_CHANGES = GetModConfigData("warly_changes"),
     --WARLY_FOOD_TASTE = GetModConfigData("warly_food_taste_"),

--- a/postinit/components/retrofitcavemap_anr.lua
+++ b/postinit/components/retrofitcavemap_anr.lua
@@ -14,6 +14,9 @@ local function RetrofitArchivesBridge()
 	if #centers == 0 then
 		return false
 	end
+	if #start == 0 then
+		return false
+	end
 	local dist = 120
 	local minidx = 1
 	for i,v in ipairs(centers) do

--- a/scripts/stategraphs/SGhoodedwidow.lua
+++ b/scripts/stategraphs/SGhoodedwidow.lua
@@ -639,7 +639,7 @@ local states =
                 WebMortar(inst, -30)
                 WebMortar(inst, 30)
 
-                UMCommonFns.RestartTimer(inst, {name = "mortar", time = inst.components.health:GetPercent() < .5 and 25 or 30) + math.random(-3, 5)}) --Under half health she speeeeds up
+                UMCommonFns.RestartTimer(inst, {name = "mortar", time = (inst.components.health:GetPercent() < .5 and 25 or 30) + math.random(-3, 5)}) --Under half health she speeeeds up
             end),
         },
 
@@ -763,7 +763,7 @@ local states =
         {
             EventHandler("animover", function(inst)
                 inst.SoundEmitter:PlaySound("dontstarve/creatures/spiderqueen/scream_short")
-                UMCommonFns.RestartTimer(inst, {name = "pounce", time = inst.components.health:GetPercent() < .5 and 15 or 20) + math.random(-3, 5)}) --Under half health she speeeeds up
+                UMCommonFns.RestartTimer(inst, {name = "pounce", time = (inst.components.health:GetPercent() < .5 and 15 or 20) + math.random(-3, 5)}) --Under half health she speeeeds up
                 if inst.oldtarget and inst.oldtarget:IsValid() and inst.components.combat then
                     inst.components.combat:SuggestTarget(inst.oldtarget)
                 end


### PR DESCRIPTION
feat(init): 添加Wormwood光合作用配置选项

新增WORMWOOD_PHOTOSYNTHESIS配置项以支持Wormwood角色得技能树选项配置。

fix(retrofit): 修复洞穴地图桥接时的数组越界问题

添加对空起始数组的检查，防止在没有有效起点时进行错误的地图改造操作
```